### PR TITLE
Add robots.txt via Next.js 14 App Router convention

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,12 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/_next/', '/revalidate', '/subscribe'],
+    },
+    sitemap: 'https://www.sensiblelivingfoundation.org/sitemap.xml',
+  }
+}


### PR DESCRIPTION
Created app/robots.ts to serve /robots.txt using Next.js metadata route handler. Allows all crawlers on public pages, disallows internal API and revalidation routes, and references the sitemap URL.

Closes #35