### PR TITLE
Wire all donate buttons to Givebutter campaign

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -147,9 +147,9 @@ export default function About() {
               </div>
 
               <div className="pt-4">
-                <Link href="/get-involved#donate" className="btn-green">
+                <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-green">
                   Support the Mission
-                </Link>
+                </a>
               </div>
             </div>
           </div>
@@ -416,7 +416,7 @@ export default function About() {
           <h2 className="font-serif text-display-md text-slf-charcoal mb-4">Join the mission.</h2>
           <p className="text-gray-500 mb-8">Whether you donate, volunteer, or spread the word — every action matters.</p>
           <div className="flex flex-wrap justify-center gap-4">
-            <Link href="/get-involved#donate" className="btn-yellow">Donate</Link>
+            <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-yellow">Donate</a>
             <Link href="/get-involved#volunteer" className="btn-green">Volunteer</Link>
           </div>
         </div>

--- a/frontend/app/financial-sense/page.tsx
+++ b/frontend/app/financial-sense/page.tsx
@@ -35,12 +35,14 @@ export default function FinancialSense() {
               >
                 Request Programming
               </Link>
-              <Link
-                href="/get-involved#donate"
+              <a
+                href="https://givebutter.com/sensefund"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="px-8 py-4 rounded border-2 border-white text-white font-bold text-sm uppercase tracking-wide hover:bg-white hover:text-blue-900 transition-colors"
               >
                 Support the Program
-              </Link>
+              </a>
             </div>
           </div>
 
@@ -365,10 +367,10 @@ export default function FinancialSense() {
               className="bg-white text-red-600 px-8 py-4 rounded font-bold text-sm uppercase tracking-wide hover:bg-gray-100 transition-colors">
               Request Programming
             </Link>
-            <Link href="/get-involved#donate"
+            <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer"
               className="border-2 border-white text-white px-8 py-4 rounded font-bold text-sm uppercase tracking-wide hover:bg-white/10 transition-colors">
               Donate to the Program
-            </Link>
+            </a>
           </div>
         </div>
       </section>

--- a/frontend/app/get-involved/DonationForm.tsx
+++ b/frontend/app/get-involved/DonationForm.tsx
@@ -48,9 +48,9 @@ export default function DonationForm() {
       <input type="text" placeholder="Full Name" className="input mb-3" />
       <input type="email" placeholder="Email Address" className="input mb-4" />
 
-      <button className="btn-yellow w-full justify-center !rounded">
+      <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-yellow w-full justify-center !rounded">
         Donate {selected !== "Other" ? selected : ""} {freq === "Give Monthly" ? "/ Month" : ""} →
-      </button>
+      </a>
       <p className="text-center text-xs text-gray-400 mt-3">
         Secure · Tax-deductible · 501(c)(3) · EIN: 99-2323968
       </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,9 +55,9 @@ export default function Home() {
             </div>
 
             <div className="flex flex-wrap gap-4">
-              <Link href="/get-involved#donate" className="btn-yellow">
+              <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-yellow">
                 Give Today
-              </Link>
+              </a>
               <Link href="/about" className="btn-ghost">
                 Our Story
               </Link>
@@ -90,18 +90,21 @@ export default function Home() {
             {/* Amount grid */}
             <div className="grid grid-cols-3 gap-2 mb-5">
               {["$25", "$50", "$100", "$250", "$500", "Other"].map((amt) => (
-                <button key={amt}
-                  className="py-3 text-sm font-bold border-2 border-gray-100 rounded hover:border-yellow-400 transition-colors text-gray-700">
+                <a key={amt}
+                  href="https://givebutter.com/sensefund"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="py-3 text-sm font-bold border-2 border-gray-100 rounded hover:border-yellow-400 transition-colors text-gray-700 flex items-center justify-center">
                   {amt}
-                </button>
+                </a>
               ))}
             </div>
 
             <input type="email" placeholder="Your email address" className="input mb-3" />
 
-            <button className="btn-yellow w-full justify-center !rounded">
+            <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-yellow w-full justify-center !rounded">
               Donate Now →
-            </button>
+            </a>
 
             <p className="text-center text-xs text-gray-400 mt-3">
               Secure · Tax-deductible · No fees
@@ -359,7 +362,7 @@ export default function Home() {
               {
                 icon: "❤️", title: "Donate",
                 desc: "Help fund the development of Sense Gardens pilot sites and Financial Sense programming in Phoenix.",
-                href: "/get-involved#donate", cta: "Give Now",
+                href: "https://givebutter.com/sensefund", cta: "Give Now",
                 bg: "#1B4332",
               },
               {
@@ -387,11 +390,19 @@ export default function Home() {
                 <span className="text-4xl mb-5">{item.icon}</span>
                 <h3 className="font-display font-bold text-lg mb-3">{item.title}</h3>
                 <p className="text-sm opacity-80 leading-relaxed mb-8 flex-1">{item.desc}</p>
-                <Link href={item.href}
-                  className="inline-flex items-center justify-center py-3 rounded font-display font-bold text-xs uppercase tracking-widest transition-all"
-                  style={{ background: "#FFCA0A", color: "#1A1A1A" }}>
-                  {item.cta} →
-                </Link>
+                {item.href.startsWith("http") ? (
+                  <a href={item.href} target="_blank" rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center py-3 rounded font-display font-bold text-xs uppercase tracking-widest transition-all"
+                    style={{ background: "#FFCA0A", color: "#1A1A1A" }}>
+                    {item.cta} →
+                  </a>
+                ) : (
+                  <Link href={item.href}
+                    className="inline-flex items-center justify-center py-3 rounded font-display font-bold text-xs uppercase tracking-widest transition-all"
+                    style={{ background: "#FFCA0A", color: "#1A1A1A" }}>
+                    {item.cta} →
+                  </Link>
+                )}
               </div>
             ))}
           </div>

--- a/frontend/app/recipes/page.tsx
+++ b/frontend/app/recipes/page.tsx
@@ -495,9 +495,9 @@ export default function RecipesPage() {
             fresh produce — and fresh ideas — to more families.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
-            <Link href="/get-involved#donate" className="btn-green">
+            <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="btn-green">
               Support the Garden
-            </Link>
+            </a>
             <Link href="/sense-gardens" className="btn-ghost" style={{ color: "#1B4332", border: "2px solid #1B4332" }}>
               Explore Sense Gardens
             </Link>

--- a/frontend/app/sense-gardens/page.tsx
+++ b/frontend/app/sense-gardens/page.tsx
@@ -21,7 +21,7 @@ export default function SenseGardens() {
               Sense Gardens is building a modern solution: space-efficient, water-smart vertical and hydroponic garden systems designed for urban communities — starting with pilot programs right here in Phoenix.
             </p>
             <div className="flex flex-wrap gap-4">
-              <a className="px-8 py-4 rounded font-bold text-sm uppercase tracking-widest transition-colors hover:opacity-90" style={{ background: "#FFCA0A", color: "#222520" }} href="/get-involved#donate">Support the Mission</a>
+              <a className="px-8 py-4 rounded font-bold text-sm uppercase tracking-widest transition-colors hover:opacity-90" style={{ background: "#FFCA0A", color: "#222520" }} href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer">Support the Mission</a>
               <a className="px-8 py-4 rounded border-2 border-gray-500 text-white font-bold text-sm uppercase tracking-widest hover:border-white transition-colors" href="/sense-gardens/map">View the Map</a>
             </div>
           </div>
@@ -38,7 +38,7 @@ export default function SenseGardens() {
               <button className="py-3 border-2 rounded font-bold text-sm transition-colors" style={{ borderColor: "#e5e7eb", color: "#374151" }}>Give Monthly</button>
             </div>
             <input type="email" placeholder="Email address" className="w-full px-4 py-3 border border-gray-200 rounded text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-yellow-400" />
-            <button type="submit" className="w-full py-4 font-bold text-sm uppercase tracking-widest rounded transition-colors hover:opacity-90" style={{ background: "#FFCA0A", color: "#222520" }}>Donate Now</button>
+            <a href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer" className="w-full py-4 font-bold text-sm uppercase tracking-widest rounded transition-colors hover:opacity-90 flex items-center justify-center" style={{ background: "#FFCA0A", color: "#222520" }}>Donate Now</a>
             <p className="text-xs text-gray-400 text-center mt-4">Secure donation via Givebutter · Tax-deductible · EIN: 99-2323968</p>
           </div>
         </div>
@@ -317,7 +317,7 @@ export default function SenseGardens() {
               <div key={item.amt} className="border border-gray-100 rounded-xl p-8 hover:shadow-md transition-shadow group cursor-pointer hover:border-yellow-300">
                 <p className="font-serif text-4xl font-extrabold text-gray-900 mb-3 group-hover:text-yellow-600 transition-colors">{item.amt}</p>
                 <p className="text-gray-500 text-sm leading-relaxed mb-6">{item.desc}</p>
-                <a className="inline-block px-6 py-3 rounded text-sm font-bold uppercase tracking-wide transition-colors" style={{ background: "#FFCA0A", color: "#222520" }} href="/get-involved#donate">Give {item.amt}</a>
+                <a className="inline-block px-6 py-3 rounded text-sm font-bold uppercase tracking-wide transition-colors" style={{ background: "#FFCA0A", color: "#222520" }} href="https://givebutter.com/sensefund" target="_blank" rel="noopener noreferrer">Give {item.amt}</a>
               </div>
             ))}
           </div>


### PR DESCRIPTION
All donate CTAs across the site were pointing to /get-involved#donate which showed a static UI widget with no live payment connection. Updated every donate button site-wide to route directly to givebutter.com/sensefund.

Pages updated: homepage, sense-gardens, get-involved (DonationForm), about, financial-sense, recipes.

Closes #38