### PR TITLE
Connect static newsletter and interest list forms to HubSpot backend

### DIFF
--- a/frontend/app/components/NewsletterForm.tsx
+++ b/frontend/app/components/NewsletterForm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+
+export default function NewsletterForm() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+    setStatus("loading");
+    try {
+      const res = await fetch("/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, firstName: name }),
+      });
+      setStatus(res.ok ? "success" : "error");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="max-w-md mx-auto py-4 text-center">
+        <p className="font-semibold text-lg" style={{ color: "#2D6A4F" }}>
+          Thanks for subscribing! We'll be in touch.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
+      <input
+        type="text"
+        placeholder="Your name"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        className="input flex-1 !rounded"
+      />
+      <input
+        type="email"
+        placeholder="Email address"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        required
+        className="input flex-1 !rounded"
+      />
+      <button
+        type="submit"
+        disabled={status === "loading"}
+        className="btn-yellow !rounded !py-3 disabled:opacity-60"
+      >
+        {status === "loading" ? "Subscribing..." : "Subscribe"}
+      </button>
+      {status === "error" && (
+        <p className="text-red-500 text-sm mt-2 w-full text-center">
+          Something went wrong. Please try again.
+        </p>
+      )}
+    </form>
+  );
+}

--- a/frontend/app/financial-sense/page.tsx
+++ b/frontend/app/financial-sense/page.tsx
@@ -1,8 +1,37 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 
 export default function FinancialSense() {
+  const [formData, setFormData] = useState({ firstName: "", lastName: "", email: "", phone: "" });
+  const [formStatus, setFormStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+
+  async function handleInterestSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!formData.email) return;
+    setFormStatus("loading");
+    try {
+      const res = await fetch("/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: formData.email,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          phone: formData.phone || undefined,
+        }),
+      });
+      setFormStatus(res.ok ? "success" : "error");
+    } catch {
+      setFormStatus("error");
+    }
+  }
+
+  function updateField(field: keyof typeof formData) {
+    return (e: React.ChangeEvent<HTMLInputElement>) =>
+      setFormData(prev => ({ ...prev, [field]: e.target.value }));
+  }
   return (
     <div>
 
@@ -57,23 +86,38 @@ export default function FinancialSense() {
               Our Financial Sense program is launching in Phoenix in 2026. Join the interest list and
               we'll reach out when enrollment opens — always at no cost.
             </p>
-            <form className="space-y-4">
-              <div className="grid grid-cols-2 gap-3">
-                <input type="text" placeholder="First Name"
-                  className="px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
-                <input type="text" placeholder="Last Name"
-                  className="px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
+            {formStatus === "success" ? (
+              <div className="py-6 text-center">
+                <p className="font-semibold text-lg" style={{ color: "#06205C" }}>
+                  You're on the list! We'll reach out when enrollment opens.
+                </p>
               </div>
-              <input type="email" placeholder="Email Address"
-                className="w-full px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
-              <input type="tel" placeholder="Phone Number (optional)"
-                className="w-full px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
-              <button type="submit"
-                className="w-full py-4 text-white font-bold text-sm uppercase tracking-wide rounded transition-colors hover:opacity-90"
-                style={{ background: "#E1251B" }}>
-                Join the Interest List
-              </button>
-            </form>
+            ) : (
+              <form className="space-y-4" onSubmit={handleInterestSubmit}>
+                <div className="grid grid-cols-2 gap-3">
+                  <input type="text" placeholder="First Name" value={formData.firstName}
+                    onChange={updateField("firstName")}
+                    className="px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
+                  <input type="text" placeholder="Last Name" value={formData.lastName}
+                    onChange={updateField("lastName")}
+                    className="px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
+                </div>
+                <input type="email" placeholder="Email Address" value={formData.email}
+                  onChange={updateField("email")} required
+                  className="w-full px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
+                <input type="tel" placeholder="Phone Number (optional)" value={formData.phone}
+                  onChange={updateField("phone")}
+                  className="w-full px-4 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-900" />
+                <button type="submit" disabled={formStatus === "loading"}
+                  className="w-full py-4 text-white font-bold text-sm uppercase tracking-wide rounded transition-colors hover:opacity-90 disabled:opacity-60"
+                  style={{ background: "#E1251B" }}>
+                  {formStatus === "loading" ? "Submitting..." : "Join the Interest List"}
+                </button>
+                {formStatus === "error" && (
+                  <p className="text-red-500 text-sm text-center">Something went wrong. Please try again.</p>
+                )}
+              </form>
+            )}
             <p className="text-xs text-gray-400 text-center mt-4">
               Always at no cost. No financial product sales. We'll contact you when enrollment opens.
             </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import NewsletterForm from "./components/NewsletterForm";
 
 // Homepage — cherry-picking best elements from all 5 reference sites
 // charity:water: dark hero, yellow CTA, stat dashboard, warm cream, category toggles
@@ -424,11 +425,7 @@ export default function Home() {
             Get program updates, pilot milestones, and ways to get involved.
             No spam. Unsubscribe anytime.
           </p>
-          <div className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
-            <input type="text" placeholder="Your name" className="input flex-1 !rounded" />
-            <input type="email" placeholder="Email address" className="input flex-1 !rounded" />
-            <button className="btn-yellow !rounded !py-3">Subscribe</button>
-          </div>
+          <NewsletterForm />
         </div>
       </section>
 

--- a/frontend/app/sense-gardens/page.tsx
+++ b/frontend/app/sense-gardens/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import NewsletterForm from "../components/NewsletterForm";
 
 export default function SenseGardens() {
   return (
@@ -422,11 +423,7 @@ export default function SenseGardens() {
         <div className="max-w-2xl mx-auto px-6 text-center">
           <h2 className="font-serif text-3xl font-extrabold text-gray-900 mb-3">Add Impact to Your Inbox</h2>
           <p className="text-gray-500 mb-8">Garden updates, pilot program milestones, and ways to help — delivered to your inbox.</p>
-          <div className="flex flex-col sm:flex-row gap-3">
-            <input type="text" placeholder="Your name" className="px-5 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-yellow-400 flex-1" />
-            <input type="email" placeholder="Email address" className="px-5 py-3 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-yellow-400 flex-1" />
-            <button className="px-7 py-3 rounded font-bold text-sm uppercase tracking-wide transition-colors hover:opacity-90" style={{ background: "#FFCA0A", color: "#222520" }}>Subscribe</button>
-          </div>
+          <NewsletterForm />
         </div>
       </section>
     </div>

--- a/frontend/app/subscribe/route.ts
+++ b/frontend/app/subscribe/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
   try {
-    const { email, firstName, lastName } = await request.json();
+    const { email, firstName, lastName, phone } = await request.json();
 
     if (!email) {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
@@ -26,6 +26,7 @@ export async function POST(request: NextRequest) {
           email,
           firstname: firstName ?? "",
           lastname: lastName ?? "",
+          ...(phone ? { phone } : {}),
           lifecyclestage: "subscriber",
           hs_lead_status: "NEW",
         },


### PR DESCRIPTION
Three forms across the site were collecting no data. Created a reusable NewsletterForm client component that posts to the existing /subscribe API route, which creates contacts in HubSpot. Wired the homepage and Sense Gardens newsletter sections to use it. Connected the Financial Sense interest list form with full field support including optional phone number. All forms show success and error feedback states.

Closes #39