### PR TITLE
Add meta titles, Open Graph tags, and canonical URLs to all pages

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -2,8 +2,21 @@ import Link from "next/link";
 import Image from "next/image";
 
 export const metadata = {
-  title: "About | Sensible Living Foundation",
-  description: "Learn about the Sensible Living Foundation, our founder, mission, and vision.",
+  title: "About Us | Sensible Living Foundation - Mission & Story",
+  description:
+    "Learn about the Sensible Living Foundation, our founder's story, and our mission to improve wealth and health outcomes in underserved Phoenix communities.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org/about",
+  },
+  openGraph: {
+    title: "About Us | Sensible Living Foundation",
+    description:
+      "Learn about our founder's story and our mission to improve wealth and health outcomes in underserved Phoenix communities.",
+    url: "https://www.sensiblelivingfoundation.org/about",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/founder/founder.jpg", width: 1200, height: 630, alt: "Sensible Living Foundation founder" }],
+    type: "website",
+  },
 };
 
 export default function About() {

--- a/frontend/app/blog/layout.tsx
+++ b/frontend/app/blog/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Blog | Sensible Living Foundation - News & Updates",
+  description:
+    "Stay informed with the latest news, program updates, and community stories from the Sensible Living Foundation. Financial literacy, food access, and more.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org/blog",
+  },
+  openGraph: {
+    title: "Blog | Sensible Living Foundation - News & Updates",
+    description:
+      "Latest news, program updates, and community stories from the Sensible Living Foundation.",
+    url: "https://www.sensiblelivingfoundation.org/blog",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/community/com_1.jpeg", width: 1200, height: 630, alt: "Sensible Living Foundation blog" }],
+    type: "website",
+  },
+};
+
+export default function BlogLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/app/financial-sense/layout.tsx
+++ b/frontend/app/financial-sense/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Financial Sense | Free Financial Literacy Program - Phoenix",
+  description:
+    "No-cost financial literacy education for individuals and families in Phoenix. Launching 2026. Join the interest list for budgeting, credit, and wealth-building courses.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org/financial-sense",
+  },
+  openGraph: {
+    title: "Financial Sense | Free Financial Literacy Program - Phoenix",
+    description:
+      "No-cost financial literacy education for Phoenix families. Launching 2026. Join the interest list today.",
+    url: "https://www.sensiblelivingfoundation.org/financial-sense",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/community/com_1.jpeg", width: 1200, height: 630, alt: "Financial Sense program - free financial literacy in Phoenix" }],
+    type: "website",
+  },
+};
+
+export default function FinancialSenseLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/app/get-involved/layout.tsx
+++ b/frontend/app/get-involved/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Get Involved | Donate, Volunteer & Partner with SLF",
+  description:
+    "Donate, volunteer, or become a community partner with the Sensible Living Foundation. Help us bring financial literacy and food access programs to Phoenix.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org/get-involved",
+  },
+  openGraph: {
+    title: "Get Involved | Donate, Volunteer & Partner with SLF",
+    description:
+      "Donate, volunteer, or partner with the Sensible Living Foundation to bring financial literacy and food access to Phoenix.",
+    url: "https://www.sensiblelivingfoundation.org/get-involved",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/community/com_1.jpeg", width: 1200, height: 630, alt: "Get involved with the Sensible Living Foundation" }],
+    type: "website",
+  },
+};
+
+export default function GetInvolvedLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,23 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sensible Living Foundation | Financial Literacy & Food Access",
+  description:
+    "Helping underserved communities in Phoenix build financial freedom and access fresh food through Financial Sense and Sense Gardens. Donate or volunteer today.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org",
+  },
+  openGraph: {
+    title: "Sensible Living Foundation | Financial Literacy & Food Access",
+    description:
+      "Helping underserved communities in Phoenix build financial freedom and access fresh food. Donate or volunteer today.",
+    url: "https://www.sensiblelivingfoundation.org",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/community/com_1.jpeg", width: 1200, height: 630, alt: "Sensible Living Foundation community programs in Phoenix" }],
+    type: "website",
+  },
+};
 
 // Homepage — cherry-picking best elements from all 5 reference sites
 // charity:water: dark hero, yellow CTA, stat dashboard, warm cream, category toggles

--- a/frontend/app/sense-gardens/layout.tsx
+++ b/frontend/app/sense-gardens/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sense Gardens | Community Gardens in Phoenix Food Deserts",
+  description:
+    "Vertical and hydroponic gardens bringing fresh food to Phoenix food deserts. Support our pilot program, volunteer, or partner to grow healthier communities.",
+  alternates: {
+    canonical: "https://www.sensiblelivingfoundation.org/sense-gardens",
+  },
+  openGraph: {
+    title: "Sense Gardens | Community Gardens in Phoenix Food Deserts",
+    description:
+      "Vertical and hydroponic gardens bringing fresh food to Phoenix food deserts. Support our pilot program today.",
+    url: "https://www.sensiblelivingfoundation.org/sense-gardens",
+    siteName: "Sensible Living Foundation",
+    images: [{ url: "https://www.sensiblelivingfoundation.org/images/gardens/gard_1.jpeg", width: 1200, height: 630, alt: "Sense Gardens vertical hydroponic garden system in Phoenix" }],
+    type: "website",
+  },
+};
+
+export default function SenseGardensLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
Every page now has a unique meta title, meta description, canonical URL, and Open Graph tags (og:title, og:description, og:image, og:url). Canonical set to www.sensiblelivingfoundation.org as preferred domain.

Pages without use client export metadata directly from page.tsx. Pages with use client use a thin layout.tsx wrapper per Next.js 14 App Router convention.

Pages: homepage, /about, /financial-sense, /sense-gardens, /get-involved, /blog


Closes #31