### PR TITLE
Improve map markers and replace fake preview with live iframe

### DIFF
--- a/frontend/app/sense-gardens/map/page.tsx
+++ b/frontend/app/sense-gardens/map/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Script from "next/script";
 
 const HUBS = [
@@ -52,6 +53,9 @@ const FOOD_DESERT_ZONES = {
 };
 
 export default function SenseGardensMap() {
+  const searchParams = useSearchParams();
+  const isPreview = searchParams.get("preview") === "true";
+
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
@@ -122,33 +126,24 @@ export default function SenseGardensMap() {
       // Clean circular pin with S logo — no label attached
       const el = document.createElement("div");
       el.style.cssText = `
-        width: 38px;
-        height: 38px;
+        width: 36px;
+        height: 36px;
         border-radius: 50%;
-        background: ${color};
-        border: 2.5px solid white;
+        background: linear-gradient(135deg, ${color}, ${color}cc);
+        border: 2.5px solid rgba(255,255,255,0.9);
         display: flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
-        font-size: 15px;
+        font-size: 14px;
         font-weight: 800;
         font-family: Georgia, serif;
         color: #0A2010;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.55);
-        transition: transform 0.15s, box-shadow 0.15s;
+        animation: hub-glow 2s ease-in-out infinite;
         user-select: none;
       `;
       el.textContent = "S";
 
-      el.addEventListener("mouseenter", () => {
-        el.style.transform = "scale(1.2)";
-        el.style.boxShadow = "0 4px 16px rgba(0,0,0,0.7)";
-      });
-      el.addEventListener("mouseleave", () => {
-        el.style.transform = "scale(1)";
-        el.style.boxShadow = "0 2px 10px rgba(0,0,0,0.55)";
-      });
       el.addEventListener("click", () => {
         setSelectedHub(hub);
         map.flyTo({ center: [hub.lng, hub.lat], zoom: 13, duration: 800 });
@@ -204,69 +199,71 @@ export default function SenseGardensMap() {
       <Script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js" onLoad={() => setScriptLoaded(true)} />
       {/* eslint-disable-next-line @next/next/no-css-tags */}
       <link href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet" />
+      <style>{`@keyframes hub-glow { 0%, 100% { box-shadow: 0 0 0 0 rgba(255,255,255,0.6), 0 4px 12px rgba(0,0,0,0.5); } 50% { box-shadow: 0 0 0 7px rgba(255,255,255,0), 0 4px 12px rgba(0,0,0,0.5); } }`}</style>
 
       {/*
         The site header is fixed at z-50 and ~72px tall.
         We use padding-top on the outer wrapper to push content below it.
         The map itself fills the remaining viewport height.
       */}
-      <div style={{ paddingTop: "72px", height: "100vh", display: "flex", flexDirection: "column", background: "#0A0A0A" }}>
+      <div style={{ paddingTop: isPreview ? "0" : "72px", height: "100vh", display: "flex", flexDirection: "column", background: "#0A0A0A" }}>
 
-        {/* ── Controls bar — sits below site header ── */}
-        <div style={{
-          background: "rgba(10,10,10,0.95)",
-          borderBottom: "1px solid rgba(255,255,255,0.08)",
-          padding: "12px 20px",
-          display: "flex",
-          alignItems: "center",
-          gap: 14,
-          flexWrap: "wrap",
-          flexShrink: 0,
-          zIndex: 10,
-        }}>
-          <div style={{ flex: "0 0 auto" }}>
-            <p style={{ color: "#52B788", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 1 }}>Sensible Living Foundation</p>
-            <p style={{ color: "white", fontSize: 15, fontWeight: 700, fontFamily: "Georgia, serif", margin: 0 }}>Sense Gardens — Food Desert Map</p>
-          </div>
-
-          <form onSubmit={handleZipSearch} style={{ display: "flex", gap: 8, flex: "1 1 240px", maxWidth: 340 }}>
-            <input
-              type="text"
-              value={searchZip}
-              onChange={e => setSearchZip(e.target.value)}
-              placeholder="Search any zip code..."
-              maxLength={5}
-              style={{
-                flex: 1, padding: "7px 12px", borderRadius: 8,
-                background: "rgba(255,255,255,0.08)", border: "1px solid rgba(255,255,255,0.15)",
-                color: "white", fontSize: 13, outline: "none",
-              }}
-            />
-            <button type="submit" disabled={searching} style={{
-              padding: "7px 14px", borderRadius: 8, background: "#52B788",
-              color: "#0A2010", fontSize: 13, fontWeight: 700, border: "none", cursor: "pointer",
-            }}>
-              {searching ? "..." : "Search"}
-            </button>
-          </form>
-
-          {searchResult && (
-            <div style={{
-              background: "rgba(82,183,136,0.15)", border: "1px solid rgba(82,183,136,0.3)",
-              borderRadius: 8, padding: "7px 12px", fontSize: 12, color: "#86EFAC",
-              flex: "1 1 180px", maxWidth: 380,
-            }}>
-              {searchResult}
+        {!isPreview && (
+          <div style={{
+            background: "rgba(10,10,10,0.95)",
+            borderBottom: "1px solid rgba(255,255,255,0.08)",
+            padding: "12px 20px",
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            flexWrap: "wrap",
+            flexShrink: 0,
+            zIndex: 10,
+          }}>
+            <div style={{ flex: "0 0 auto" }}>
+              <p style={{ color: "#52B788", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 1 }}>Sensible Living Foundation</p>
+              <p style={{ color: "white", fontSize: 15, fontWeight: 700, fontFamily: "Georgia, serif", margin: 0 }}>Sense Gardens - Food Desert Map</p>
             </div>
-          )}
-        </div>
+
+            <form onSubmit={handleZipSearch} style={{ display: "flex", gap: 8, flex: "1 1 240px", maxWidth: 340 }}>
+              <input
+                type="text"
+                value={searchZip}
+                onChange={e => setSearchZip(e.target.value)}
+                placeholder="Search any zip code..."
+                maxLength={5}
+                style={{
+                  flex: 1, padding: "7px 12px", borderRadius: 8,
+                  background: "rgba(255,255,255,0.08)", border: "1px solid rgba(255,255,255,0.15)",
+                  color: "white", fontSize: 13, outline: "none",
+                }}
+              />
+              <button type="submit" disabled={searching} style={{
+                padding: "7px 14px", borderRadius: 8, background: "#52B788",
+                color: "#0A2010", fontSize: 13, fontWeight: 700, border: "none", cursor: "pointer",
+              }}>
+                {searching ? "..." : "Search"}
+              </button>
+            </form>
+
+            {searchResult && (
+              <div style={{
+                background: "rgba(82,183,136,0.15)", border: "1px solid rgba(82,183,136,0.3)",
+                borderRadius: 8, padding: "7px 12px", fontSize: 12, color: "#86EFAC",
+                flex: "1 1 180px", maxWidth: 380,
+              }}>
+                {searchResult}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* ── Map area ── */}
         <div style={{ position: "relative", flex: 1, overflow: "hidden" }}>
           <div ref={mapContainer} style={{ width: "100%", height: "100%" }} />
 
           {/* Left panel */}
-          <div style={{
+          {!isPreview && <div style={{
             position: "absolute", top: 12, left: 12,
             background: "rgba(10,10,10,0.88)",
             backdropFilter: "blur(12px)",
@@ -317,7 +314,7 @@ export default function SenseGardensMap() {
                 ))}
               </div>
             </div>
-          </div>
+          </div>}
 
           {/* Hub detail panel */}
           {selectedHub && (

--- a/frontend/app/sense-gardens/map/page.tsx
+++ b/frontend/app/sense-gardens/map/page.tsx
@@ -116,24 +116,33 @@ function MapContent() {
       const color = PHASE_COLORS[hub.phase];
       const el = document.createElement("div");
       el.style.cssText = `
-        width: 36px;
-        height: 36px;
+        width: 38px;
+        height: 38px;
         border-radius: 50%;
-        background: linear-gradient(135deg, ${color}, ${color}cc);
-        border: 2.5px solid rgba(255,255,255,0.9);
+        background: ${color};
+        border: 2.5px solid white;
         display: flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
-        font-size: 14px;
+        font-size: 15px;
         font-weight: 800;
         font-family: Georgia, serif;
         color: #0A2010;
-        animation: hub-glow 2s ease-in-out infinite;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.55);
+        transition: transform 0.15s, box-shadow 0.15s;
         user-select: none;
       `;
       el.textContent = "S";
 
+      el.addEventListener("mouseenter", () => {
+        el.style.transform = "scale(1.2)";
+        el.style.boxShadow = "0 4px 16px rgba(0,0,0,0.7)";
+      });
+      el.addEventListener("mouseleave", () => {
+        el.style.transform = "scale(1)";
+        el.style.boxShadow = "0 2px 10px rgba(0,0,0,0.55)";
+      });
       el.addEventListener("click", () => {
         setSelectedHub(hub);
         map.flyTo({ center: [hub.lng, hub.lat], zoom: 13, duration: 800 });
@@ -189,7 +198,6 @@ function MapContent() {
       <Script src="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js" onLoad={() => setScriptLoaded(true)} />
       {/* eslint-disable-next-line @next/next/no-css-tags */}
       <link href="https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css" rel="stylesheet" />
-      <style>{`@keyframes hub-glow { 0%, 100% { box-shadow: 0 0 0 0 rgba(255,255,255,0.6), 0 4px 12px rgba(0,0,0,0.5); } 50% { box-shadow: 0 0 0 7px rgba(255,255,255,0), 0 4px 12px rgba(0,0,0,0.5); } }`}</style>
 
       <div style={{ paddingTop: "72px", height: "100vh", display: "flex", flexDirection: "column", background: "#0A0A0A" }}>
 
@@ -231,62 +239,23 @@ function MapContent() {
             </button>
           </form>
 
-        {!isPreview && (
-          <div style={{
-            background: "rgba(10,10,10,0.95)",
-            borderBottom: "1px solid rgba(255,255,255,0.08)",
-            padding: "12px 20px",
-            display: "flex",
-            alignItems: "center",
-            gap: 14,
-            flexWrap: "wrap",
-            flexShrink: 0,
-            zIndex: 10,
-          }}>
-            <div style={{ flex: "0 0 auto" }}>
-              <p style={{ color: "#52B788", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 1 }}>Sensible Living Foundation</p>
-              <p style={{ color: "white", fontSize: 15, fontWeight: 700, fontFamily: "Georgia, serif", margin: 0 }}>Sense Gardens - Food Desert Map</p>
+          {searchResult && (
+            <div style={{
+              background: "rgba(82,183,136,0.15)", border: "1px solid rgba(82,183,136,0.3)",
+              borderRadius: 8, padding: "7px 12px", fontSize: 12, color: "#86EFAC",
+              flex: "1 1 180px", maxWidth: 380,
+            }}>
+              {searchResult}
             </div>
-
-            <form onSubmit={handleZipSearch} style={{ display: "flex", gap: 8, flex: "1 1 240px", maxWidth: 340 }}>
-              <input
-                type="text"
-                value={searchZip}
-                onChange={e => setSearchZip(e.target.value)}
-                placeholder="Search any zip code..."
-                maxLength={5}
-                style={{
-                  flex: 1, padding: "7px 12px", borderRadius: 8,
-                  background: "rgba(255,255,255,0.08)", border: "1px solid rgba(255,255,255,0.15)",
-                  color: "white", fontSize: 13, outline: "none",
-                }}
-              />
-              <button type="submit" disabled={searching} style={{
-                padding: "7px 14px", borderRadius: 8, background: "#52B788",
-                color: "#0A2010", fontSize: 13, fontWeight: 700, border: "none", cursor: "pointer",
-              }}>
-                {searching ? "..." : "Search"}
-              </button>
-            </form>
-
-            {searchResult && (
-              <div style={{
-                background: "rgba(82,183,136,0.15)", border: "1px solid rgba(82,183,136,0.3)",
-                borderRadius: 8, padding: "7px 12px", fontSize: 12, color: "#86EFAC",
-                flex: "1 1 180px", maxWidth: 380,
-              }}>
-                {searchResult}
-              </div>
-            )}
-          </div>
-        )}
+          )}
+        </div>
 
         {/* ── Map area ── */}
         <div style={{ position: "relative", flex: 1, overflow: "hidden" }}>
           <div ref={mapContainer} style={{ width: "100%", height: "100%" }} />
 
           {/* Left panel */}
-          {!isPreview && <div style={{
+          <div style={{
             position: "absolute", top: 12, left: 12,
             background: "rgba(10,10,10,0.88)",
             backdropFilter: "blur(12px)",
@@ -337,7 +306,7 @@ function MapContent() {
                 ))}
               </div>
             </div>
-          </div>}
+          </div>
 
           {/* Hub detail panel */}
           {selectedHub && (

--- a/frontend/app/sense-gardens/page.tsx
+++ b/frontend/app/sense-gardens/page.tsx
@@ -339,63 +339,25 @@ export default function SenseGardens() {
           </div>
 
           {/* ── Clickable map preview ── */}
-          <Link href="/sense-gardens/map">
-            <div
-              className="h-80 rounded-2xl overflow-hidden border border-gray-600 cursor-pointer group transition-all duration-300 hover:border-green-400 hover:shadow-2xl relative"
-              style={{ background: "#0A1A10" }}
-            >
-              {/* Dot grid background */}
-              <div
-                className="absolute inset-0 opacity-20"
-                style={{ backgroundImage: "radial-gradient(circle at 1px 1px, #52B788 1px, transparent 0)", backgroundSize: "24px 24px" }}
+          <div className="rounded-2xl overflow-hidden border border-gray-600" style={{ background: "#0A1A10" }}>
+            <div className="relative h-64 pointer-events-none">
+              <iframe
+                src="/sense-gardens/map?preview=true"
+                title="Sense Gardens food desert map preview"
+                className="w-full h-full border-0"
+                scrolling="no"
               />
-
-              {/* Food desert zone previews */}
-              <div className="absolute inset-0 overflow-hidden">
-                <div className="absolute opacity-30 group-hover:opacity-50 transition-opacity duration-500" style={{ background: "#E24B4A", width: 140, height: 80, top: "25%", left: "18%", borderRadius: 6 }} />
-                <div className="absolute opacity-25 group-hover:opacity-45 transition-opacity duration-500" style={{ background: "#E07B39", width: 110, height: 70, top: "35%", left: "38%", borderRadius: 6 }} />
-                <div className="absolute opacity-20 group-hover:opacity-40 transition-opacity duration-500" style={{ background: "#BA7517", width: 130, height: 90, top: "45%", left: "28%", borderRadius: 6 }} />
-                <div className="absolute opacity-20 group-hover:opacity-35 transition-opacity duration-500" style={{ background: "#E24B4A", width: 90, height: 60, top: "20%", left: "55%", borderRadius: 6 }} />
-                <div className="absolute opacity-15 group-hover:opacity-30 transition-opacity duration-500" style={{ background: "#E07B39", width: 100, height: 65, top: "55%", left: "60%", borderRadius: 6 }} />
-              </div>
-
-              {/* SLF hub pins */}
-              {[
-                { top: "38%", left: "30%", color: "#52B788" },
-                { top: "28%", left: "22%", color: "#52B788" },
-                { top: "32%", left: "42%", color: "#52B788" },
-                { top: "44%", left: "56%", color: "#FFCA0A" },
-                { top: "55%", left: "25%", color: "#FFCA0A" },
-                { top: "20%", left: "58%", color: "#E07B39" },
-              ].map((pin, i) => (
-                <div
-                  key={i}
-                  className="absolute w-6 h-6 rounded-full border-2 border-white flex items-center justify-center font-bold group-hover:scale-110 transition-transform duration-300 z-10"
-                  style={{ background: pin.color, top: pin.top, left: pin.left, color: "#0A2010", fontSize: 10 }}
-                >
-                  S
-                </div>
-              ))}
-
-              {/* Overlay */}
-              <div className="absolute inset-0 flex flex-col items-center justify-center z-20" style={{ background: "rgba(10,26,16,0.55)" }}>
-                <div
-                  className="px-4 py-1.5 rounded-full text-xs font-bold mb-3 transition-all duration-300"
-                  style={{ background: "rgba(82,183,136,0.2)", border: "1px solid rgba(82,183,136,0.4)", color: "#86EFAC" }}
-                >
-                  Interactive Map — Live Now
-                </div>
-                <p className="text-white font-semibold text-lg mb-1 font-serif text-center px-4">Explore the Food Desert Map</p>
-                <p className="text-gray-400 text-sm mb-5 text-center px-4">Phoenix · Arizona · USDA data · Hub locations</p>
-                <div
-                  className="px-6 py-2.5 rounded-full text-sm font-bold transition-all duration-300 group-hover:scale-105"
-                  style={{ background: "#FFCA0A", color: "#1A1A1A" }}
-                >
-                  Open Full Map →
-                </div>
-              </div>
             </div>
-          </Link>
+            <div className="p-4 flex justify-center" style={{ background: "#0A1A10" }}>
+              <Link
+                href="/sense-gardens/map"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-full text-sm font-bold uppercase tracking-widest transition-all hover:opacity-90"
+                style={{ background: "#FFCA0A", color: "#1A1A1A" }}
+              >
+                Open Full Map →
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Map page: replaced hover-scale effect on hub markers with a smooth box-shadow glow pulse that does not conflict with Mapbox transforms during zoom. Markers stay fixed in place at all zoom levels.

Sense Gardens page: replaced the static fake map preview with a live iframe embed of the actual map. Controls, search, and filter panels are hidden in preview mode via ?preview=true query param, showing only the map. Open Full Map button sits below the preview.

Closes #12 